### PR TITLE
fixed: Wine.getProgramFiles()

### DIFF
--- a/Functions/Engines/Wine/script.js
+++ b/Functions/Engines/Wine/script.js
@@ -179,7 +179,7 @@ var Wine = function () {
     };
 
     that.getProgramFiles = function() {
-        var programFilesName = that.run("cmd", ["/c", "echo", "%ProgramFiles%"], true);
+        var programFilesName = that.run("cmd", ["/c", "echo", "%ProgramFiles%"], true).trim();
         if(programFilesName == "%ProgramFiles%") {
             return "Program Files"
         } else {


### PR DESCRIPTION
fixes: Wine.getProgramFiles() returns string with line break at the end #4